### PR TITLE
Relax rxdart version constraint

### DIFF
--- a/packages/iabtcf_consent_info/pubspec.yaml
+++ b/packages/iabtcf_consent_info/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  rxdart: ^0.26.0
+  rxdart: '>=0.26.0 <0.28.0'
   iabtcf_consent_info_platform_interface: ^1.0.5
   iabtcf_consent_info_web: ^3.0.0
 dev_dependencies:

--- a/packages/iabtcf_consent_info/pubspec.yaml
+++ b/packages/iabtcf_consent_info/pubspec.yaml
@@ -1,7 +1,7 @@
 name: iabtcf_consent_info
-description: >- 
-  Flutter plugin for reading IAB TCF v2.0 user consent information, such as 
-  made available through CMP SDKs, like Funding Choices's 
+description: >-
+  Flutter plugin for reading IAB TCF v2.0 user consent information, such as
+  made available through CMP SDKs, like Funding Choices's
   User Messaging Platform (UMP).
 version: 3.0.0
 repository: https://github.com/blaugold/iabtcf_consent_info


### PR DESCRIPTION
`rxdart` 0.27.0 has been released almost 1,5 year ago and some important packages depend on it, e.g. `riverpod`. Current requirement of version 0.26.0 is thus problematic.

To my understanding [the breaking changes in 0.27.0](https://pub.dev/packages/rxdart/changelog#0270) do not affect `iabtcf_consent_info`. Please note that I don't have enough knowledge to be 100% confident. However the tests pass and I successfully use the fork in my application. 