### PR TITLE
build: Add gradle namespace property for AGP 8.x support

### DIFF
--- a/packages/iabtcf_consent_info/android/build.gradle
+++ b/packages/iabtcf_consent_info/android/build.gradle
@@ -27,6 +27,10 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 31
 
+    if (project.android.hasProperty('namespace')) {
+        namespace 'com.terwesten.gabriel.iabtcf_consent_info'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/packages/iabtcf_consent_info/android/src/main/AndroidManifest.xml
+++ b/packages/iabtcf_consent_info/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.gabriel.terwesten.iabtcf_consent_info">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
I have no actual understanding of the change. I just pieced it together by looking at how `googleads_mobile_flutter` did it. See [issue](https://github.com/googleads/googleads-mobile-flutter/issues/839) and [PR](https://github.com/googleads/googleads-mobile-flutter/pull/843/files). It seems to work though.