### PR TITLE
consentInfo() always return the updated value, closes #7

### DIFF
--- a/packages/iabtcf_consent_info/lib/iabtcf_consent_info.dart
+++ b/packages/iabtcf_consent_info/lib/iabtcf_consent_info.dart
@@ -306,10 +306,10 @@ class IabtcfConsentInfo {
   static late final instance = IabtcfConsentInfo._();
 
   // ignore: close_sinks
-  late final _consentInfo = ReplaySubject<BasicConsentInfo?>(
-    maxSize: 1,
-    onListen: _onConsentInfoListen,
-    onCancel: _onConsentInfoCancel,
+  late final _consentInfo = BehaviorSubject<BasicConsentInfo?>(
+      onListen: _onConsentInfoListen,
+      onCancel: _onConsentInfoCancel,
+      sync: true
   );
 
   late StreamSubscription<void> _rawConsentInfoSub;


### PR DESCRIPTION
Using BehaviorSubject, the value is always the most recent one. Also sync is needed to have consistency.